### PR TITLE
update workers to use serveSinglePageApp

### DIFF
--- a/workers-site/.gitignore
+++ b/workers-site/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+worker

--- a/workers-site/index.js
+++ b/workers-site/index.js
@@ -1,0 +1,34 @@
+import {
+  getAssetFromKV,
+  mapRequestToAsset,
+  serveSinglePageApp,
+} from '@cloudflare/kv-asset-handler';
+
+/**
+ * The DEBUG flag will do two things that help during development:
+ * 1. we will skip caching on the edge, which makes it easier to
+ *    debug.
+ * 2. we will return an error message on exception in your Response rather
+ *    than the default 404.html page.
+ */
+const DEBUG = false;
+
+addEventListener('fetch', event => {
+  try {
+    event.respondWith(handleEvent(event));
+  } catch (e) {
+    if (DEBUG) {
+      return event.respondWith(
+        new Response(e.message || e.toString(), {
+          status: 500,
+        })
+      );
+    }
+    event.respondWith(new Response('Internal Error', { status: 500 }));
+  }
+});
+
+async function handleEvent(event) {
+  const response = await getAssetFromKV(event, { mapRequestToAsset: serveSinglePageApp });
+  return response;
+}

--- a/workers-site/package-lock.json
+++ b/workers-site/package-lock.json
@@ -1,0 +1,50 @@
+{
+  "name": "worker",
+  "version": "1.0.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "worker",
+      "version": "1.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "@cloudflare/kv-asset-handler": "~0.1.2"
+      }
+    },
+    "node_modules/@cloudflare/kv-asset-handler": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.1.2.tgz",
+      "integrity": "sha512-otES1gV5mEhNh82p/sJERPMMrC7UOLV2JyfKf4e3EX1TmMkZ3N8IDGAqRNsoRU8UYTO7wc83I7pH1p4ozAdgMQ==",
+      "dependencies": {
+        "mime": "^2.5.2"
+      }
+    },
+    "node_modules/mime": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.5.2.tgz",
+      "integrity": "sha512-tqkh47FzKeCPD2PUiPB6pkbMzsCasjxAfC62/Wap5qrUWcb+sFasXUC5I3gYM5iBM8v/Qpn4UK0x+j0iHyFPDg==",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    }
+  },
+  "dependencies": {
+    "@cloudflare/kv-asset-handler": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.1.2.tgz",
+      "integrity": "sha512-otES1gV5mEhNh82p/sJERPMMrC7UOLV2JyfKf4e3EX1TmMkZ3N8IDGAqRNsoRU8UYTO7wc83I7pH1p4ozAdgMQ==",
+      "requires": {
+        "mime": "^2.5.2"
+      }
+    },
+    "mime": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.5.2.tgz",
+      "integrity": "sha512-tqkh47FzKeCPD2PUiPB6pkbMzsCasjxAfC62/Wap5qrUWcb+sFasXUC5I3gYM5iBM8v/Qpn4UK0x+j0iHyFPDg=="
+    }
+  }
+}

--- a/workers-site/package.json
+++ b/workers-site/package.json
@@ -1,0 +1,12 @@
+{
+  "private": true,
+  "name": "worker",
+  "version": "1.0.0",
+  "description": "A template for kick starting a Cloudflare Workers project",
+  "main": "index.js",
+  "author": "Ashley Lewis <ashleymichal@gmail.com>",
+  "license": "MIT",
+  "dependencies": {
+    "@cloudflare/kv-asset-handler": "~0.1.2"
+  }
+}


### PR DESCRIPTION
Normally workers will try to map every request to `index.html` within the requested folder.

This change redirects it to use the base `index.html` so the React Router functions as expected.