### PR TITLE
Add sponsored tx

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,8 +52,7 @@
   "scripts": {
     "start": "vite",
     "build": "CI= tsc && vite build",
-    "serve": "vite preview",
-    "dev": "netlify dev --target-port 4173"
+    "serve": "vite preview"
   },
   "eslintConfig": {
     "extends": "react-app"

--- a/src/components/SendManyInputContainer.tsx
+++ b/src/components/SendManyInputContainer.tsx
@@ -682,6 +682,11 @@ export function SendManyInputContainer({
         )}
 
         <div>{preview}</div>
+        {useAssetForFees && (
+          <div>
+            <small>The transaction fees are sponsored by {NOT_SPONSOR}</small>
+          </div>
+        )}
         <div className="input-group mt-2">
           <button className="btn btn-block btn-primary" type="button" onClick={sendAction}>
             <div

--- a/src/components/SendManyInputContainer.tsx
+++ b/src/components/SendManyInputContainer.tsx
@@ -1,4 +1,5 @@
 import {
+  AuthType,
   bufferCVFromString,
   contractPrincipalCV,
   createAssetInfo,
@@ -44,6 +45,7 @@ import { saveTxData, TxStatus } from '../lib/transactions';
 import { Address } from './Address';
 import { Amount } from './Amount';
 import { SendManyInput } from './SendManyInput';
+import { Network } from './Network';
 export type Row = {
   to: string;
   stx: string;
@@ -241,6 +243,16 @@ export function SendManyInputContainer({
 
   const sendAsset = async (options: ContractCallOptions) => {
     const handleSendResult = (data: Pick<FinishedTxData, 'txId'> & Partial<FinishedTxData>) => {
+      console.log({ data });
+      if (data.stacksTransaction?.auth.authType === AuthType.Sponsored) {
+        fetch('https://sponsoring.friedger.workers.dev/not', {
+          method: 'POST',
+          body: JSON.stringify({ txHex: data.txRaw, feesInNot: TX_FEE_IN_NOT, network: 'mainnet' }),
+          headers: { 'Content-Type': 'text/plain' },
+        })
+          .then(r => console.log({ r }))
+          .catch(e => console.log(e));
+      }
       setStatus('Saving transaction to your storage');
       setTxId(data.txId);
       if (userSession) {
@@ -491,8 +503,8 @@ export function SendManyInputContainer({
     return newRows;
   };
 
-  const NOT_SPONSOR = 'SP1K1A1PMGW2ZJCNF46NWZWHG8TS1D23EGH1KNK60';
-  const txFeeInNot = '10000';
+  const NOT_SPONSOR = 'SPM1NE6JPN9V1019930579E7EZ58FYKMD17J7RS';
+  const TX_FEE_IN_NOT = '100000';
 
   const cloneAndAddFees = (rows: Row[]) => {
     const newRows = new Array(...rows);
@@ -502,7 +514,7 @@ export function SendManyInputContainer({
 
   const feesRow = (asset: string): Row => {
     if (asset === 'not') {
-      return { to: NOT_SPONSOR, stx: txFeeInNot, memo: 'fees' };
+      return { to: NOT_SPONSOR, stx: TX_FEE_IN_NOT, memo: 'fees' };
     } else {
       throw new Error(`unsupported asset ${asset}`);
     }

--- a/src/components/SendManyInputContainer.tsx
+++ b/src/components/SendManyInputContainer.tsx
@@ -271,9 +271,28 @@ export function SendManyInputContainer({
         })
           .then(response => {
             if (!response.ok) {
-              response.json().then(({ error }: { error: string }) => {
-                setStatus(error);
-              });
+              response
+                .json()
+                .then((error: { error: string }) => {
+                  console.log(error);
+                  setStatus(error.error);
+                  setLoading(false);
+                })
+                .catch(e => {
+                  console.log(e);
+                  response
+                    .text()
+                    .then(t => {
+                      console.log(t, response);
+                      setStatus(`Response status: ${response.status}  ${t}`);
+                      setLoading(false);
+                    })
+                    .catch(e => {
+                      console.log(e);
+                      setStatus(`Response status: ${response.status}`);
+                      setLoading(false);
+                    });
+                });
             } else {
               response
                 .json()
@@ -297,8 +316,11 @@ export function SendManyInputContainer({
             }
           })
           .catch(e => {
-            setStatus(e);
             console.log(e);
+            setStatus(
+              'Failed to pay fees in NOT and broadcast the tx, please contact web administrator.'
+            );
+            setLoading(false);
           });
       } else {
         handleSave(data);

--- a/src/components/SendManyInputContainer.tsx
+++ b/src/components/SendManyInputContainer.tsx
@@ -45,7 +45,6 @@ import { saveTxData, TxStatus } from '../lib/transactions';
 import { Address } from './Address';
 import { Amount } from './Amount';
 import { SendManyInput } from './SendManyInput';
-import { Network } from './Network';
 export type Row = {
   to: string;
   stx: string;

--- a/src/lib/transactions.tsx
+++ b/src/lib/transactions.tsx
@@ -1,12 +1,8 @@
-import {
-  GetFilteredEventsTypeEnum,
-  TransactionEventsResponse,
-  connectWebSocketClient,
-} from '@stacks/blockchain-api-client';
+import { TransactionEventsResponse, connectWebSocketClient } from '@stacks/blockchain-api-client';
 import { FinishedTxData, UserSession } from '@stacks/connect';
 import { Storage } from '@stacks/storage';
 import { hexToCV as stacksHexToCV } from '@stacks/transactions';
-import { TransitionEvent, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import {
   STACKS_API_WS_URL,
   STACK_API_URL,
@@ -250,7 +246,7 @@ async function createTxWithApiData(
   let eventOffset = 0;
   const eventLimit = 20;
   let events: TransactionEvent[] = [];
-  let apiData: ContractCallTransaction;
+  let apiData: ContractCallTransaction | MempoolContractCallTransaction;
   let moreEvents = true;
   let lastEventsLength = 0;
 
@@ -258,7 +254,8 @@ async function createTxWithApiData(
     txId,
     eventOffset,
     eventLimit,
-  })) as ContractCallTransaction;
+    unanchored: true,
+  })) as ContractCallTransaction | MempoolContractCallTransaction;
 
   const isOutOfMempool = mempoolStatuses.includes(apiData?.tx_status as MempoolTransactionStatus);
   if (!isOutOfMempool && apiData.tx_status === 'success') {

--- a/src/lib/transactions.tsx
+++ b/src/lib/transactions.tsx
@@ -1,8 +1,12 @@
-import { connectWebSocketClient } from '@stacks/blockchain-api-client';
+import {
+  GetFilteredEventsTypeEnum,
+  TransactionEventsResponse,
+  connectWebSocketClient,
+} from '@stacks/blockchain-api-client';
 import { FinishedTxData, UserSession } from '@stacks/connect';
 import { Storage } from '@stacks/storage';
 import { hexToCV as stacksHexToCV } from '@stacks/transactions';
-import { useEffect, useState } from 'react';
+import { TransitionEvent, useEffect, useState } from 'react';
 import {
   STACKS_API_WS_URL,
   STACK_API_URL,
@@ -211,6 +215,15 @@ async function getTxWithoutStorage(txId: string) {
   return createTxWithApiData(txId, { data: { txId } });
 }
 
+const mempoolStatuses: MempoolTransactionStatus[] = [
+  'dropped_problematic',
+  'dropped_replace_across_fork',
+  'dropped_replace_by_fee',
+  'dropped_stale_garbage_collect',
+  'dropped_too_expensive',
+  'pending',
+];
+
 export async function getTx(txId: string, userSession: UserSession) {
   if (userSession && userSession.isUserSignedIn()) {
     const storage = new Storage({ userSession });
@@ -220,42 +233,70 @@ export async function getTx(txId: string, userSession: UserSession) {
   }
 }
 
+function joinEvents(allEvents: TransactionEvent[], newEvents: TransactionEvent[]) {
+  newEvents.forEach(event => {
+    const pos = allEvents.findIndex(e => event.event_index === e.event_index);
+    if (pos < 0) {
+      allEvents.push(event);
+    }
+  });
+  return allEvents;
+}
 async function createTxWithApiData(
   txId: string,
   tx: { data: { txId: string } },
   storage?: Storage
 ) {
   let eventOffset = 0;
-  const eventLimit = 400;
+  const eventLimit = 20;
   let events: TransactionEvent[] = [];
-  let apiData: Transaction | MempoolTransaction | null = null;
+  let apiData: ContractCallTransaction;
   let moreEvents = true;
-  while (moreEvents) {
-    eventOffset = events.length;
-    // FIXME: what if a transaction doesn't exist?
-    apiData = (await transactionsApi.getTransactionById({
-      txId,
-      eventOffset,
-      eventLimit,
-    })) as ContractCallTransaction | MempoolContractCallTransaction;
+  let lastEventsLength = 0;
 
-    const mempoolStatuses: MempoolTransactionStatus[] = [
-      'dropped_problematic',
-      'dropped_replace_across_fork',
-      'dropped_replace_by_fee',
-      'dropped_stale_garbage_collect',
-      'dropped_too_expensive',
-      'pending',
-    ];
-    const isOutOfMempool = mempoolStatuses.includes(apiData?.tx_status as MempoolTransactionStatus);
+  apiData = (await transactionsApi.getTransactionById({
+    txId,
+    eventOffset,
+    eventLimit,
+  })) as ContractCallTransaction;
 
-    if (isOutOfMempool) {
-      const data = apiData as ContractCallTransaction;
-      console.log(eventOffset, data.events.length, data.event_count);
-      events = events.concat(data.events);
-      console.log(data.event_count);
+  const isOutOfMempool = mempoolStatuses.includes(apiData?.tx_status as MempoolTransactionStatus);
+  if (!isOutOfMempool && apiData.tx_status === 'success') {
+    console.log(apiData.events.length, apiData.event_count);
+    moreEvents = apiData.events.length < apiData.event_count;
+
+    let eventsResponse: TransactionEventsResponse | undefined;
+    while (moreEvents) {
+      /*
+      eventsResponse = await transactionsApi.getFilteredEvents({
+        txId: '76bfd6994e7d1aa74693fca166f5f0299485f4ba918c30e7260a8c073296f36b',
+        type: [
+          GetFilteredEventsTypeEnum.fungible_token_asset,
+          GetFilteredEventsTypeEnum.non_fungible_token_asset,
+          GetFilteredEventsTypeEnum.smart_contract_log,
+          GetFilteredEventsTypeEnum.stx_asset,
+          GetFilteredEventsTypeEnum.stx_lock,
+        ],
+        offset: eventOffset,
+        limit: eventLimit,
+      });
+      */
+      apiData = (await transactionsApi.getTransactionById({
+        txId,
+        eventOffset,
+        eventLimit,
+      })) as ContractCallTransaction;
+
+      console.log({ eventsResponse });
+
+      const data = apiData;
+      console.log(eventOffset, data.events.length, apiData.event_count);
+      events = joinEvents(events, data.events);
+      moreEvents = events.length > lastEventsLength;
+      lastEventsLength = events.length;
+      eventOffset = lastEventsLength;
+      console.log(isOutOfMempool, events.length, apiData.event_count, lastEventsLength);
     }
-    moreEvents = apiData.tx_status === 'success' && events.length !== apiData.event_count;
   }
   const txWithApiData: StoredTx = {
     ...tx,

--- a/src/pages/Landing.tsx
+++ b/src/pages/Landing.tsx
@@ -37,7 +37,7 @@ export default function Landing({
                 <>
                   A UI to interact with the smart contracts
                   <br />
-                  "send-many", "send-many-memo", "nothing" and "xbtc-send-many-v1".
+                  "send-many", "send-many-memo", "nope" and "xbtc-send-many-v1".
                 </>
               )}
             </p>
@@ -51,12 +51,12 @@ export default function Landing({
                 open source
               </a>{' '}
               web app with the purpose of{' '}
-              <strong>helping everybody to send and view bulk STX/xBTC/WMNO transfers.</strong>
+              <strong>helping everybody to send and view bulk STX/xBTC/NOT transfers.</strong>
             </p>
 
             <div className="card mt-4 border-info">
               <div className="card-header">
-                <h5 className="card-title">Efficient STX/xBTC/WMNO transfers</h5>
+                <h5 className="card-title">Efficient STX/xBTC/NOT transfers</h5>
               </div>
               <div className="card-body">
                 <p className="card-text mb-3">
@@ -91,7 +91,7 @@ export default function Landing({
               </p>
 
               <div className="card-footer text-info">
-                <strong>With additional features for Wrapped Nothing</strong>
+                <strong>With additional features for Nothing</strong>
               </div>
             </div>
           </div>


### PR DESCRIPTION
This PR
* allows users to use pay fee in NOT tokens when transferring NOT to many users.

The user creates a sponsored send-many transaction that contains an extra row for the tx fee sponsor and 0 STX as fees
Then the signed tx is send to the backend, signed by the sponsored and broadcasted. The sponsor service is available at https://github.com/friedger/stacks-not-sponsoring


![image](https://github.com/friedger/stacks-send-many/assets/1449049/4d1b51dc-f2c8-420d-9b88-88b321947956)

