### PR TITLE
Use pills for assets

### DIFF
--- a/src/pages/SendMany.tsx
+++ b/src/pages/SendMany.tsx
@@ -57,31 +57,22 @@ export default function SendMany({
 
               <div className="col-sm-12 col-md-8 p-4 container">
                 <div className="col-xs-10 col-md-12 bg-light p-4">
-                  <div className="text-right">
-                    Send{' '}
-                    {SUPPORTED_SYMBOLS.filter(a => a !== asset).map(a => {
+                  <div className="asset-pills">
+                    {SUPPORTED_SYMBOLS.map(a => {
+                      const url = network === 'mainnet'
+                        ? a === 'stx' ? '/' : `/${a}`
+                        : network === 'testnet'
+                          ? a === 'stx' ? '/?chain=testnet' : `/${a}?chain=testnet`
+                          : a === 'stx' ? '/?chain=mocknet' : `/${a}?chain=mocknet`;
+                      
                       return (
-                        <>
-                          <Link
-                            to={
-                              network === 'mainnet'
-                                ? a === 'stx'
-                                  ? '/'
-                                  : `/${a}`
-                                : network === 'testnet'
-                                  ? a === 'stx'
-                                    ? '/?chain=testnet'
-                                    : `/${a}?chain=testnet`
-                                  : a === 'stx'
-                                    ? '/?chain=mocknet'
-                                    : `/${a}?chain=mocknet`
-                            }
-                            className="small"
-                          >
-                            {testnet || mocknet ? 'Test' : ''} {SUPPORTED_ASSETS[a].shortName}{' '}
-                          </Link>
-                          {' - '}
-                        </>
+                        <Link
+                          key={a}
+                          to={url}
+                          className={`asset-pill ${a === asset ? 'active' : ''}`}
+                        >
+                          {testnet || mocknet ? 'Test ' : ''}{SUPPORTED_ASSETS[a].shortName}
+                        </Link>
                       );
                     })}
                   </div>

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -73,21 +73,30 @@ inspect {
 }
 
 .asset-pill {
-  padding: 0.5rem 1rem;
-  border-radius: 20px;
+  padding: 0.375rem 0.75rem;
+  border-radius: 0.375rem;
   text-decoration: none;
-  background-color: var(--brand-greyish);
-  color: #666;
-  transition: all 0.2s ease;
+  background-color: #f8f9fa;
+  border: 1px solid #dee2e6;
+  color: #212529;
+  transition: color .15s ease-in-out,background-color .15s ease-in-out,border-color .15s ease-in-out,box-shadow .15s ease-in-out;
 }
 
 .asset-pill:hover {
-  background-color: var(--brand-mild);
-  color: var(--brand-dark);
+  background-color: #e9ecef;
+  border-color: #dee2e6;
+  color: #212529;
   text-decoration: none;
 }
 
 .asset-pill.active {
-  background-color: var(--brand-bright);
+  background-color: #0d6efd;
+  border-color: #0d6efd;
+  color: white;
+}
+
+.asset-pill.active:hover {
+  background-color: #0b5ed7;
+  border-color: #0a58ca;
   color: white;
 }

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -64,3 +64,30 @@ inspect {
 .balance {
   font-size: 20pt;
 }
+
+.asset-pills {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.asset-pill {
+  padding: 0.5rem 1rem;
+  border-radius: 20px;
+  text-decoration: none;
+  background-color: var(--brand-greyish);
+  color: #666;
+  transition: all 0.2s ease;
+}
+
+.asset-pill:hover {
+  background-color: var(--brand-mild);
+  color: var(--brand-dark);
+  text-decoration: none;
+}
+
+.asset-pill.active {
+  background-color: var(--brand-bright);
+  color: white;
+}


### PR DESCRIPTION
Updates the supported assets layout from text to tag-style buttons.

![Screenshot from 2024-12-22 23-25-22](https://github.com/user-attachments/assets/88a4d83e-3c69-45fa-b897-f7b6c2bb35e6)

Seems easier to read/select than just the text, open to feedback.